### PR TITLE
Info.plistの多言語対応

### DIFF
--- a/KyotoTrip.xcodeproj/project.pbxproj
+++ b/KyotoTrip.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		4C52ACCB2497BCCD00200B52 /* LanguageSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C52ACCA2497BCCD00200B52 /* LanguageSettings.swift */; };
 		4C52ACCD2497C10F00200B52 /* LanguageSettingsCellViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C52ACCC2497C10F00200B52 /* LanguageSettingsCellViewData.swift */; };
 		4C52ACCF249847FE00200B52 /* LanguageSettingGateway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C52ACCE249847FE00200B52 /* LanguageSettingGateway.swift */; };
+		4C5334F824AB77EF00DF68F7 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4C5334FA24AB77EF00DF68F7 /* InfoPlist.strings */; };
 		4C5A33E72483F1150041FE48 /* CategoryButtonStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5A33E62483F1150041FE48 /* CategoryButtonStatus.swift */; };
 		4C5A5DF1248610CF001EA2CE /* SettingsInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C5A5DF0248610CF001EA2CE /* SettingsInteractorTests.swift */; };
 		4C7BC1F62489F7E900A5C394 /* InfoInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7BC1F52489F7E900A5C394 /* InfoInteractorTests.swift */; };
@@ -188,6 +189,8 @@
 		4C52ACCA2497BCCD00200B52 /* LanguageSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSettings.swift; sourceTree = "<group>"; };
 		4C52ACCC2497C10F00200B52 /* LanguageSettingsCellViewData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSettingsCellViewData.swift; sourceTree = "<group>"; };
 		4C52ACCE249847FE00200B52 /* LanguageSettingGateway.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageSettingGateway.swift; sourceTree = "<group>"; };
+		4C5334F924AB77EF00DF68F7 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		4C5334FB24AB77F600DF68F7 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		4C5A33E62483F1150041FE48 /* CategoryButtonStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryButtonStatus.swift; sourceTree = "<group>"; };
 		4C5A5DF0248610CF001EA2CE /* SettingsInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsInteractorTests.swift; sourceTree = "<group>"; };
 		4C7BC1F52489F7E900A5C394 /* InfoInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoInteractorTests.swift; sourceTree = "<group>"; };
@@ -601,6 +604,7 @@
 			isa = PBXGroup;
 			children = (
 				4CC1AE0F2424615D00BF84B9 /* Localizable.strings */,
+				4C5334FA24AB77EF00DF68F7 /* InfoPlist.strings */,
 			);
 			path = Localize;
 			sourceTree = "<group>";
@@ -1024,6 +1028,7 @@
 				4C2BA4282484C9D10018B435 /* gnaviAPIDummyResponse.json in Resources */,
 				4CA84AD4245036F000DAC5F3 /* BusstopDetail.storyboard in Resources */,
 				4CF773E0241B97900032CC53 /* Assets.xcassets in Resources */,
+				4C5334F824AB77EF00DF68F7 /* InfoPlist.strings in Resources */,
 				4CC1AE0D2424615D00BF84B9 /* Localizable.strings in Resources */,
 				4CC1ADD7241BB13700BF84B9 /* Map.storyboard in Resources */,
 				4CF4AFF22470AC7A00991B2C /* SettingsRestaurantsSearchRange.storyboard in Resources */,
@@ -1333,6 +1338,15 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		4C5334FA24AB77EF00DF68F7 /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4C5334F924AB77EF00DF68F7 /* en */,
+				4C5334FB24AB77F600DF68F7 /* ja */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
 		4CC1AE0F2424615D00BF84B9 /* Localizable.strings */ = {
 			isa = PBXVariantGroup;
 			children = (

--- a/KyotoTrip/Common/Localize/en.lproj/InfoPlist.strings
+++ b/KyotoTrip/Common/Localize/en.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* 
+  InfoPlist.strings
+  KyotoTrip
+
+  Created by TANAKA MASAYUKI on 2020/06/30.
+  Copyright © 2020 TANAKA MASAYUKI. All rights reserved.
+*/
+"NSLocationWhenInUseUsageDescription" = "This application requires location services to work";

--- a/KyotoTrip/Common/Localize/ja.lproj/InfoPlist.strings
+++ b/KyotoTrip/Common/Localize/ja.lproj/InfoPlist.strings
@@ -1,0 +1,8 @@
+/* 
+  InfoPlist.strings
+  KyotoTrip
+
+  Created by TANAKA MASAYUKI on 2020/06/30.
+  Copyright © 2020 TANAKA MASAYUKI. All rights reserved.
+*/
+"NSLocationWhenInUseUsageDescription" = "現在地情報を利用します";

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ KyotoTrip is iOS app for Visitors.
 Source Code
 --------------------------
 
-![Unit Tests](https://github.com/masayuki5160/KyotoTrip/workflows/Unit%20Tests/badge.svg)
-![Upload IPA to App Store Connect](https://github.com/masayuki5160/KyotoTrip/workflows/Upload%20IPA%20to%20App%20Store%20Connect/badge.svg)
+![Unit Tests](https://github.com/masayuki5160/KyotoTrip/workflows/Unit%20Tests/badge.svg?branch=develop)
+![Upload IPA to App Store Connect](https://github.com/masayuki5160/KyotoTrip/workflows/Upload%20IPA%20to%20App%20Store%20Connect/badge.svg?branch=master)
 
 ![](Overview.drawio.svg)
 


### PR DESCRIPTION
以下審査リジェクトに伴う対応

```
Guideline 5.1.1 - Legal - Privacy - Data Collection and Storage


We noticed that your app requests the user’s consent to access their location but does not clarify the use of the location in the applicable purpose string.

Next Steps

Please revise the relevant purpose string in your app’s Info.plist file to specify why the app is requesting access to the user's location. You can modify your app's Info.plist file using the property list editor in Xcode.

To help users understand why your app is requesting access to their personal data, all permission request alerts in your app should specify how your app will use the requested feature.

Resources

For additional information and instructions on requesting permission, please review the Requesting Permission section of the iOS Human Interface Guidelines and the Information Property List Key Reference. You may also want to review the Technical Q&A QA1937: Resolving the Privacy-Sensitive Data App Rejection page for details on how to provide a usage description for permission request alerts.

Please see attached screenshot for details.
```